### PR TITLE
Support older versions of PHP.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "flarum/core": "^0.1.0-beta.10",
     "fof/extend": ">=0.2.0",
     "matriphe/iso-639": "^1.2",
-    "rinvex/countries": "^6.1.2"
+    "rinvex/countries": "^6.1.2 || ^7.0.1"
   },
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "flarum/core": "^0.1.0-beta.10",
     "fof/extend": ">=0.2.0",
     "matriphe/iso-639": "^1.2",
-    "rinvex/countries": "^7.0.1"
+    "rinvex/countries": "^6.1.2"
   },
   "authors": [
     {


### PR DESCRIPTION
I downgraded the required version of the `rinvex/countries` (to v6.1.2) so that people can use this extensions on servers that don't have PHP 7.4. I Hope this doesn't break anything but as far as my tests went it all works fine.