### PR TITLE
Optional "Any Language" filter option

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -85,5 +85,6 @@ return [
         ->addInclude(['language']),
 
     (new Extend\Settings())
-        ->serializeToForum('fof-discussion-language.composerLocaleDefault', 'fof-discussion-language.composerLocaleDefault', 'boolVal'),
+        ->serializeToForum('fof-discussion-language.composerLocaleDefault', 'fof-discussion-language.composerLocaleDefault', 'boolVal')
+        ->serializeToForum('fof-discussion-language.showAnyLangOpt', 'fof-discussion-language.showAnyLangOpt', 'boolVal'),
 ];

--- a/js/src/admin/components/LanguagesSettingsPage.js
+++ b/js/src/admin/components/LanguagesSettingsPage.js
@@ -33,6 +33,9 @@ export default class LanguagesSettingsPage extends ExtensionPage {
 
         this.localeSortKey = 'fof-discussion-language.filter_language_on_http_request';
         this.localeSort = app.data.settings[this.localeSortKey];
+
+        this.showAnyLangOptKey = 'fof-discussion-language.showAnyLangOpt';
+        this.showAnyLangOpt = app.data.settings[this.showAnyLangOptKey];
     }
 
     content() {
@@ -82,6 +85,16 @@ export default class LanguagesSettingsPage extends ExtensionPage {
                                 onchange: (value) => (this.localeSort = value),
                             },
                             app.translator.trans('fof-discussion-language.admin.settings.locale_sort_label')
+                        )}
+                    </div>
+
+                    <div className="Form-group">
+                        {Switch.component(
+                            {
+                                state: this.showAnyLangOpt,
+                                onchange: (value) => (this.showAnyLangOpt = value),
+                            },
+                            app.translator.trans('fof-discussion-language.admin.settings.show_any_lang_opt_label')
                         )}
                     </div>
 
@@ -221,6 +234,7 @@ export default class LanguagesSettingsPage extends ExtensionPage {
                 [this.showFlagsKey]: this.showFlags,
                 [this.composerLocaleDefaultKey]: this.composerLocaleDefault,
                 [this.localeSortKey]: this.localeSort,
+                [this.showAnyLangOptKey]: this.showAnyLangOpt,
             }).then(this.onsaved.bind(this)),
         ]);
     }
@@ -254,7 +268,8 @@ export default class LanguagesSettingsPage extends ExtensionPage {
         const flag = Number(this.showFlags) !== Number(app.data.settings[this.showFlagsKey] || 0);
         const composerLocale = Number(this.composerLocaleDefault) !== Number(app.data.settings[this.composerLocaleDefaultKey] || 0);
         const locale = Number(this.localeSort) !== Number(app.data.settings[this.localeSortKey] || 0);
+        const anyOpt = Number(this.showAnyLangOpt) !== Number(app.data.settings[this.showAnyLangOptKey] || 0);
 
-        return dirty || native || flag || composerLocale || locale;
+        return dirty || native || flag || composerLocale || locale || anyOpt;
     }
 }

--- a/js/src/forum/addLanguageToDiscussionList.js
+++ b/js/src/forum/addLanguageToDiscussionList.js
@@ -31,20 +31,38 @@ export default () => {
     extend(DiscussionListState.prototype, 'requestParams', function (params) {
         params.include.push('language');
 
-        params.filter.q = (params.filter.q || '') + ' language:' + (app.search.params().language ? app.search.params().language : app.translator.formatter.locale);
+        if (app.forum.attribute('fof-discussion-language.showAnyLangOpt')) {
+            if (app.search.params().language) {
+                params.filter.q = (params.filter.q || '') + ' language:' + app.search.params().language;
+            }
+        } else {
+            params.filter.q =
+                (params.filter.q || '') +
+                ' language:' +
+                (app.search.params().language ? app.search.params().language : app.translator.formatter.locale);
+        }
     });
 
     extend(GlobalSearchState.prototype, 'stickyParams', (params) => (params.language = m.route.param('language')));
 
     extend(IndexPage.prototype, 'viewItems', function (items) {
+        let extra, defaultSelected;
+        if (app.forum.attribute('fof-discussion-language.showAnyLangOpt')) {
+            extra = { any: app.translator.trans('fof-discussion-language.forum.index_language.any') };
+            defaultSelected = 'any';
+        } else {
+            defaultSelected = app.translator.formatter.locale;
+        }
+
         items.add(
             'language',
             LanguageDropdown.component({
-                default: app.translator.formatter.locale,
+                extra,
+                default: defaultSelected,
                 onclick: (key) => {
                     const params = app.search.params();
 
-                    if (key === app.translator.formatter.locale) delete params.language;
+                    if (key === defaultSelected) delete params.language;
                     else params.language = key;
 
                     setRouteWithForcedRefresh(app.route(app.current.get('routeName'), params));

--- a/js/src/forum/addLanguageToDiscussionList.js
+++ b/js/src/forum/addLanguageToDiscussionList.js
@@ -31,9 +31,7 @@ export default () => {
     extend(DiscussionListState.prototype, 'requestParams', function (params) {
         params.include.push('language');
 
-        if (app.search.params().language) {
-            params.filter.q = (params.filter.q || '') + ' language:' + app.search.params().language;
-        }
+        params.filter.q = (params.filter.q || '') + ' language:' + (app.search.params().language ? app.search.params().language : app.translator.formatter.locale);
     });
 
     extend(GlobalSearchState.prototype, 'stickyParams', (params) => (params.language = m.route.param('language')));
@@ -42,12 +40,11 @@ export default () => {
         items.add(
             'language',
             LanguageDropdown.component({
-                extra: { any: app.translator.trans('fof-discussion-language.forum.index_language.any') },
-                default: 'any',
+                default: app.translator.formatter.locale,
                 onclick: (key) => {
                     const params = app.search.params();
 
-                    if (key === 'any') delete params.language;
+                    if (key === app.translator.formatter.locale) delete params.language;
                     else params.language = key;
 
                     setRouteWithForcedRefresh(app.route(app.current.get('routeName'), params));

--- a/js/src/forum/components/LanguageDropdown.js
+++ b/js/src/forum/components/LanguageDropdown.js
@@ -24,7 +24,13 @@ export default class LanguageDropdown extends Component {
                 label: this.options[selected] || this.options[this.attrs.default],
             },
             Object.keys(this.options).map((key) => {
-                const isSelected = selected || app.translator.formatter.locale;
+                let defaultSelected;
+                if (app.forum.attribute('fof-discussion-language.composerLocaleDefault')) {
+                    defaultSelected = 'any';
+                } else {
+                    defaultSelected = app.translator.formatter.locale;
+                }
+                const isSelected = selected || defaultSelected;
                 const active = key === isSelected;
 
                 return Button.component(

--- a/js/src/forum/components/LanguageDropdown.js
+++ b/js/src/forum/components/LanguageDropdown.js
@@ -24,7 +24,7 @@ export default class LanguageDropdown extends Component {
                 label: this.options[selected] || this.options[this.attrs.default],
             },
             Object.keys(this.options).map((key) => {
-                const isSelected = selected || 'any';
+                const isSelected = selected || app.translator.formatter.locale;
                 const active = key === isSelected;
 
                 return Button.component(

--- a/migrations/2021_06_29_000000_default_settings.php
+++ b/migrations/2021_06_29_000000_default_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of fof/discussion-language.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        /**
+         * @var SettingsRepositoryInterface
+         */
+        $settings = resolve('flarum.settings');
+
+        $settings->set('fof-discussion-language.showAnyLangOpt', true);
+    },
+    'down' => function (Builder $schema) {
+        /**
+         * @var SettingsRepositoryInterface
+         */
+        $settings = resolve('flarum.settings');
+
+        $settings->delete('fof-discussion-language.showAnyLangOpt');
+    },
+];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -21,6 +21,7 @@ fof-discussion-language:
       show_flag_label: Show country flags with language names
       composer_default_label: Pre-select current locale in the discussion composer
       locale_sort_label: Use detected language for default discussion filter
+      show_any_lang_opt_label: Show the option to select "Any Language".
 
     permissions:
       allow_change_language_label: Allow language editing

--- a/src/Middleware/AddLanguageFilter.php
+++ b/src/Middleware/AddLanguageFilter.php
@@ -14,6 +14,7 @@ namespace FoF\DiscussionLanguage\Middleware;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -61,11 +62,18 @@ class AddLanguageFilter implements MiddlewareInterface
             }
 
             if ($language) {
-                $request = $request->withQueryParams([
-                    'q' => Arr::get($params, 'q', '') . " language:$language",
-                ]);
-    
-                return $handler->handle($request);
+                if ((bool) $settings->get('fof-discussion-language.showAnyLangOpt', true)) {
+                    $uri = $request->getUri();
+                    $uri = $uri->withQuery("language=$language");
+
+                    return new RedirectResponse($uri, 303);
+                } else {
+                    $request = $request->withQueryParams([
+                        'q' => Arr::get($params, 'q', '') . " language:$language",
+                    ]);
+        
+                    return $handler->handle($request);
+                }
             }
         }
 

--- a/src/Middleware/AddLanguageFilter.php
+++ b/src/Middleware/AddLanguageFilter.php
@@ -14,7 +14,6 @@ namespace FoF\DiscussionLanguage\Middleware;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Support\Arr;
-use Laminas\Diactoros\Response\RedirectResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -62,10 +61,11 @@ class AddLanguageFilter implements MiddlewareInterface
             }
 
             if ($language) {
-                $uri = $request->getUri();
-                $uri = $uri->withQuery("language=$language");
-
-                return new RedirectResponse($uri, 303);
+                $request = $request->withQueryParams([
+                    'q' => Arr::get($params, 'q', '') . " language:$language",
+                ]);
+    
+                return $handler->handle($request);
             }
         }
 

--- a/src/Middleware/AddLanguageFilter.php
+++ b/src/Middleware/AddLanguageFilter.php
@@ -69,9 +69,9 @@ class AddLanguageFilter implements MiddlewareInterface
                     return new RedirectResponse($uri, 303);
                 } else {
                     $request = $request->withQueryParams([
-                        'q' => Arr::get($params, 'q', '') . " language:$language",
+                        'q' => Arr::get($params, 'q', '')." language:$language",
                     ]);
-        
+
                     return $handler->handle($request);
                 }
             }


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Added an admin option:
- This new option makes it possible to disable the "Any Language" filter option.
- This option is enabled by default, so there is no impact for existing installations.
- Once the option is set to false, the default selected language is the one of the user and when the user changes his language setting, it is directly reflected in the language filter for discussions.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
If this new option works fine and didn't break anything.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tested on a local Flarum installation.
