### PR TITLE
Localised tags page last discussion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,13 @@
     "ianm/iso-639": "^1.0"
   },
   "require-dev": {
-    "flarum/tags": "^1.0.0"
+    "flarum/tags": "^1.0"
+  },
+  "suggest": {
+    "flarum/tags": "This extension works well with flarum/tags."
+  },
+  "conflict": {
+    "flarum/tags": "<1.0,>=2.0"
   },
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
     "league/csv": "^9.7",
     "ianm/iso-639": "^1.0"
   },
-  "require-dev": {
-    "flarum/tags": "^1.0"
-  },
   "authors": [
     {
       "name": "David Sevilla Martin",

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,6 @@
   "require-dev": {
     "flarum/tags": "^1.0"
   },
-  "suggest": {
-    "flarum/tags": "This extension works well with flarum/tags."
-  },
-  "conflict": {
-    "flarum/tags": "<1.0,>=2.0"
-  },
   "authors": [
     {
       "name": "David Sevilla Martin",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
     "league/csv": "^9.7",
     "ianm/iso-639": "^1.0"
   },
+  "require-dev": {
+    "flarum/tags": "^1.0.0"
+  },
   "authors": [
     {
       "name": "David Sevilla Martin",

--- a/extend.php
+++ b/extend.php
@@ -24,20 +24,19 @@ use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
 use Flarum\Tags\Api\Serializer\TagSerializer;
 use Flarum\Tags\Event\Creating as TagCreating;
-
 use FoF\DiscussionLanguage\Api\Serializers\DiscussionLanguageSerializer;
 use FoF\DiscussionLanguage\Api\Serializers\TagLocalizedLastDiscussionSerializer;
 
 return [
     (new Extend\Frontend('forum'))
-        ->js(__DIR__ . '/js/dist/forum.js')
-        ->css(__DIR__ . '/resources/less/forum.less'),
+        ->js(__DIR__.'/js/dist/forum.js')
+        ->css(__DIR__.'/resources/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__ . '/js/dist/admin.js')
-        ->css(__DIR__ . '/resources/less/admin.less'),
+        ->js(__DIR__.'/js/dist/admin.js')
+        ->css(__DIR__.'/resources/less/admin.less'),
 
-    new Extend\Locales(__DIR__ . '/resources/locale'),
+    new Extend\Locales(__DIR__.'/resources/locale'),
 
     (new Extend\Routes('api'))
         ->post('/fof/discussion-language', 'fof.discussion-language.create', Api\Controllers\CreateLanguageController::class)

--- a/extend.php
+++ b/extend.php
@@ -106,7 +106,7 @@ return [
 
             // Attach discussion title as this is needed for the tags page
             foreach ($json as $languageId => $data) {
-                $data['title'] = Discussion::find($data['id'])->title;
+                $data['title'] = optional(Discussion::find($data['id']))->title || '';
                 $json[$languageId] = $data;
             }
 

--- a/extend.php
+++ b/extend.php
@@ -24,19 +24,20 @@ use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
 use Flarum\Tags\Api\Serializer\TagSerializer;
 use Flarum\Tags\Event\Creating as TagCreating;
-use Flarum\Tags\Tag;
+
 use FoF\DiscussionLanguage\Api\Serializers\DiscussionLanguageSerializer;
+use FoF\DiscussionLanguage\Api\Serializers\TagLocalizedLastDiscussionSerializer;
 
 return [
     (new Extend\Frontend('forum'))
-        ->js(__DIR__.'/js/dist/forum.js')
-        ->css(__DIR__.'/resources/less/forum.less'),
+        ->js(__DIR__ . '/js/dist/forum.js')
+        ->css(__DIR__ . '/resources/less/forum.less'),
 
     (new Extend\Frontend('admin'))
-        ->js(__DIR__.'/js/dist/admin.js')
-        ->css(__DIR__.'/resources/less/admin.less'),
+        ->js(__DIR__ . '/js/dist/admin.js')
+        ->css(__DIR__ . '/resources/less/admin.less'),
 
-    new Extend\Locales(__DIR__.'/resources/locale'),
+    new Extend\Locales(__DIR__ . '/resources/locale'),
 
     (new Extend\Routes('api'))
         ->post('/fof/discussion-language', 'fof.discussion-language.create', Api\Controllers\CreateLanguageController::class)
@@ -101,17 +102,5 @@ return [
         ->subscribe(Listener\UpdateTagMetadata::class),
 
     (new Extend\ApiSerializer(TagSerializer::class))
-        ->attributes(function (TagSerializer $serializer, Tag $tag, array $attributes) {
-            $json = json_decode($tag->localised_last_discussion, true);
-
-            // Attach discussion title as this is needed for the tags page
-            foreach ($json as $languageId => $data) {
-                $data['title'] = optional(Discussion::find($data['id']))->title || '';
-                $json[$languageId] = $data;
-            }
-
-            $attributes['localisedLastDiscussion'] = $json;
-
-            return $attributes;
-        }),
+        ->attributes(TagLocalizedLastDiscussionSerializer::class),
 ];

--- a/js/src/admin/components/LanguagesSettingsPage.js
+++ b/js/src/admin/components/LanguagesSettingsPage.js
@@ -40,6 +40,9 @@ export default class LanguagesSettingsPage extends ExtensionPage {
     this.showAnyLangOptKey = 'fof-discussion-language.showAnyLangOpt';
     this.showAnyLangOpt = app.data.settings[this.showAnyLangOptKey];
 
+    this.tagsPageDiscussionLocaleDefaultKey = 'fof-discussion-language.useLocaleForTagsPageLastDiscussion';
+    this.tagsPageDiscussionLocale = app.data.settings[this.composerLocaleDefaultKey] || 0;
+
     this.loadingData = true;
     this.loadingDataError = false;
   }
@@ -131,6 +134,16 @@ export default class LanguagesSettingsPage extends ExtensionPage {
                 onchange: (value) => (this.showAnyLangOpt = value),
               },
               app.translator.trans('fof-discussion-language.admin.settings.show_any_lang_opt_label')
+            )}
+          </div>
+
+          <div className="Form-group">
+            {Switch.component(
+              {
+                state: this.tagsPageDiscussionLocale,
+                onchange: (value) => (this.tagsPageDiscussionLocale = value),
+              },
+              app.translator.trans('fof-discussion-language.admin.settings.tags_page_discussion_locale_label')
             )}
           </div>
 
@@ -293,6 +306,7 @@ export default class LanguagesSettingsPage extends ExtensionPage {
         [this.composerLocaleDefaultKey]: this.composerLocaleDefault,
         [this.localeSortKey]: this.localeSort,
         [this.showAnyLangOptKey]: this.showAnyLangOpt,
+        [this.tagsPageDiscussionLocaleDefaultKey]: this.tagsPageDiscussionLocale,
       }).then(this.onsaved.bind(this)),
     ]);
   }
@@ -327,7 +341,8 @@ export default class LanguagesSettingsPage extends ExtensionPage {
     const composerLocale = Number(this.composerLocaleDefault) !== Number(app.data.settings[this.composerLocaleDefaultKey] || 0);
     const locale = Number(this.localeSort) !== Number(app.data.settings[this.localeSortKey] || 0);
     const anyOpt = Number(this.showAnyLangOpt) !== Number(app.data.settings[this.showAnyLangOptKey] || 0);
+    const tagsPageFilter = Number(this.tagsPageDiscussionLocaleDefault) !== Number(app.data.settings[this.tagsPageDiscussionLocaleDefaultKey] || 0);
 
-    return dirty || native || flag || composerLocale || locale || anyOpt;
+    return dirty || native || flag || composerLocale || locale || anyOpt || tagsPageFilter;
   }
 }

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -1,5 +1,6 @@
 import Model from 'flarum/common/Model';
 import Forum from 'flarum/common/models/Forum';
+import Tag from 'flarum/tags/common/models/Tag';
 import Discussion from 'flarum/common/models/Discussion';
 
 import Language from '../common/models/Language';
@@ -7,6 +8,7 @@ import Language from '../common/models/Language';
 import addEditLanguageModal from './addEditLanguageModal';
 import addLanguageComposer from './addLanguageComposer';
 import addLanguageToDiscussionList from './addLanguageToDiscussionList';
+import useLocalisedLastDiscussionOnTagsPage from './useLocalisedLastDiscussionOnTagsPage';
 
 export * from './components';
 export * from '../common/utils';
@@ -15,6 +17,8 @@ export * from '../common/models';
 app.initializers.add('fof/discussion-language', () => {
   app.store.models['discussion-languages'] = Language;
 
+  if ('flarum-tags' in flarum.extensions) Tag.prototype.localisedLastDiscussion = Model.attribute('localisedLastDiscussion');
+
   Forum.prototype.discussionLanguages = Model.hasMany('discussionLanguages');
   Discussion.prototype.language = Model.hasOne('language');
   Discussion.prototype.canChangeLanguage = Model.attribute('canChangeLanguage');
@@ -22,4 +26,5 @@ app.initializers.add('fof/discussion-language', () => {
   addEditLanguageModal();
   addLanguageComposer();
   addLanguageToDiscussionList();
+  useLocalisedLastDiscussionOnTagsPage();
 });

--- a/js/src/forum/useLocalisedLastDiscussionOnTagsPage.ts
+++ b/js/src/forum/useLocalisedLastDiscussionOnTagsPage.ts
@@ -39,8 +39,6 @@ export default function useLocalisedLastDiscussionOnTagsPage() {
 
     const discussion = data[desiredLanguageId];
 
-    console.log(data, desiredLanguageCode, desiredLanguageId, discussion);
-
     // fall back to original attribute
     if (!discussion) return original();
 

--- a/js/src/forum/useLocalisedLastDiscussionOnTagsPage.ts
+++ b/js/src/forum/useLocalisedLastDiscussionOnTagsPage.ts
@@ -1,0 +1,55 @@
+import app from 'flarum/forum/app';
+
+import Tag from 'flarum/tags/common/models/Tag';
+
+import Discussion from 'flarum/common/models/Discussion';
+import Model from 'flarum/common/Model';
+
+export default function useLocalisedLastDiscussionOnTagsPage() {
+  if (!('flarum-tags' in flarum.extensions)) return;
+
+  Tag.prototype.lastPostedDiscussion = function (this: Tag) {
+    const original = Model.hasOne('lastPostedDiscussion').bind(this);
+
+    if (!app.forum.attribute('fof-discussion-language.useLocaleForTagsPageLastDiscussion')) {
+      return original();
+    }
+
+    const data = this.localisedLastDiscussion();
+
+    /**
+     * Priorities:
+     *
+     * 1. User's selected forum locale
+     * 2. Detected locale
+     * 3. First disucssion language available
+     */
+    const desiredLanguageCode =
+      app.session.user?.preferences?.()?.locale || (app.translator as any).formatter.locale || (app.forum as any).discussionLanguages()[0].code();
+
+    const desiredLanguageId = (app.forum as any)
+      .discussionLanguages()
+      .find((lang: any) => lang.code() === desiredLanguageCode)
+      ?.id();
+
+    // If forum locale not available as a discussion lang, default to any language
+    if (!desiredLanguageId) {
+      return original();
+    }
+
+    const discussion = data[desiredLanguageId];
+
+    console.log(data, desiredLanguageCode, desiredLanguageId, discussion);
+
+    // fall back to original attribute
+    if (!discussion) return original();
+
+    return new Discussion({
+      attributes: {
+        title: discussion.title,
+        slug: discussion.id, // navigating using only ID works fine
+        lastPostedAt: new Date(discussion.at * 1000).toISOString(),
+      },
+    });
+  };
+}

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -1,44 +1,39 @@
-const { merge } = require('webpack-merge')
+const { merge } = require('webpack-merge');
 const FileManagerPlugin = require('filemanager-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const config = require('flarum-webpack-config');
 const path = require('path');
 
 module.exports = merge(config(), {
-    output: {
-        chunkFilename: 'chunk~[name].js'
-    },
-    plugins: [
-        new CleanWebpackPlugin({
-            dry: false,
-            dangerouslyAllowCleanPatternsOutsideProject: true,
-            cleanOnceBeforeBuildPatterns: [
-                path.resolve(process.cwd(), '../assets/*'),
-                path.resolve(process.cwd(), 'dist/*'),
-            ]
-        }),
-        new FileManagerPlugin({
-            events: {
-                onEnd: {
-                    copy: [
-                        { source: 'dist/chunk*', destination: '../assets/' },
-                    ],
-                },
-            },
-        }),
+  output: {
+    chunkFilename: 'chunk~[name].js',
+  },
+  plugins: [
+    new CleanWebpackPlugin({
+      dry: false,
+      dangerouslyAllowCleanPatternsOutsideProject: true,
+      cleanOnceBeforeBuildPatterns: [path.resolve(process.cwd(), '../assets/*'), path.resolve(process.cwd(), 'dist/*')],
+    }),
+    new FileManagerPlugin({
+      events: {
+        onEnd: {
+          copy: [{ source: 'dist/chunk*', destination: '../assets/' }],
+        },
+      },
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.csv$/,
+        loader: 'csv-loader',
+        options: {
+          dynamicTyping: true,
+          header: true,
+          skipEmptyLines: true,
+          comments: '#',
+        },
+      },
     ],
-    module: {
-        rules: [
-            {
-                test: /\.csv$/,
-                loader: 'csv-loader',
-                options: {
-                    dynamicTyping: true,
-                    header: true,
-                    skipEmptyLines: true,
-                    comments: '#',
-                },
-            },
-        ],
-    },
-})
+  },
+});

--- a/migrations/2021_08_20_000000_add_tags_page_only_show_locale_discussions_setting.php
+++ b/migrations/2021_08_20_000000_add_tags_page_only_show_locale_discussions_setting.php
@@ -1,0 +1,7 @@
+<?php
+
+use Flarum\Database\Migration;
+
+return Migration::addSettings([
+    'fof-discussion-language.useLocaleForTagsPageLastDiscussion' => '0',
+]); 

--- a/migrations/2021_08_20_000002_add_language_id_column.php
+++ b/migrations/2021_08_20_000002_add_language_id_column.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of fof/discussion-language.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Database\Migration;
+
+return Migration::addColumns('tags', [
+    'localised_last_discussion' => ['string', 'type' => 'TEXT'],
+]);

--- a/migrations/2022_08_20_000002_fill_language_id_column.php
+++ b/migrations/2022_08_20_000002_fill_language_id_column.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of fof/discussion-language.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Flarum\Tags\Tag;
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        Tag::all()->each(function (Tag $tag) {
+            $tag->localised_last_discussion = "{}";
+            $tag->save();
+        });
+    },
+    'down' => function (Builder $schema) {
+        // Do nothing
+    }
+];

--- a/migrations/2022_08_20_000002_fill_language_id_column.php
+++ b/migrations/2022_08_20_000002_fill_language_id_column.php
@@ -15,11 +15,11 @@ use Illuminate\Database\Schema\Builder;
 return [
     'up' => function (Builder $schema) {
         Tag::all()->each(function (Tag $tag) {
-            $tag->localised_last_discussion = "{}";
+            $tag->localised_last_discussion = '{}';
             $tag->save();
         });
     },
     'down' => function (Builder $schema) {
         // Do nothing
-    }
+    },
 ];

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -22,7 +22,7 @@ fof-discussion-language:
       composer_default_label: Pre-select current locale in the discussion composer
       locale_sort_label: Use detected language for default discussion filter
       show_any_lang_opt_label: Show the option to select "Any Language"
-      tags_page_discussion_locale_label: Only show discussions from the user's locale on the Tags page
+      tags_page_discussion_locale_label: Only show discussions from the user's current locale on the Tags page
 
       errors:
         loading_data: There was an error retrieving locale & country data. Try disabling & re-enabling the extension.

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -21,7 +21,8 @@ fof-discussion-language:
       show_flag_label: Show country flags with language names
       composer_default_label: Pre-select current locale in the discussion composer
       locale_sort_label: Use detected language for default discussion filter
-      show_any_lang_opt_label: Show the option to select "Any Language".
+      show_any_lang_opt_label: Show the option to select "Any Language"
+      tags_page_discussion_locale_label: Only show discussions from the user's locale on the Tags page
 
       errors:
         loading_data: There was an error retrieving locale & country data. Try disabling & re-enabling the extension.

--- a/src/Api/Serializers/TagLocalizedLastDiscussionSerializer.php
+++ b/src/Api/Serializers/TagLocalizedLastDiscussionSerializer.php
@@ -23,7 +23,9 @@ class TagLocalizedLastDiscussionSerializer
 
         // Attach discussion title as this is needed for the tags page
         foreach ($json as $languageId => $data) {
-            $data['title'] = optional(Discussion::find($data['id']))->title || '';
+            $discussion = optional(Discussion::find($data['id']));
+
+            $data['title'] = $discussion->title || '';
             $json[$languageId] = $data;
         }
 

--- a/src/Api/Serializers/TagLocalizedLastDiscussionSerializer.php
+++ b/src/Api/Serializers/TagLocalizedLastDiscussionSerializer.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of fof/discussion-language.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\DiscussionLanguage\Api\Serializers;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Tags\Api\Serializer\TagSerializer;
+use Flarum\Tags\Tag;
+
+class TagLocalizedLastDiscussionSerializer
+{
+    public function __invoke(TagSerializer $serializer, Tag $tag, array $attributes)
+    {
+        $json = json_decode($tag->localised_last_discussion, true);
+
+        // Attach discussion title as this is needed for the tags page
+        foreach ($json as $languageId => $data) {
+            $data['title'] = optional(Discussion::find($data['id']))->title || '';
+            $json[$languageId] = $data;
+        }
+
+        $attributes['localisedLastDiscussion'] = $json;
+
+        return $attributes;
+    }
+}

--- a/src/Listener/TagCreating.php
+++ b/src/Listener/TagCreating.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of fof/discussion-language.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\DiscussionLanguage\Listeners;
+
+use Flarum\Tags\Event\Creating;
+
+class TagCreating
+{
+    public function handle(Creating $event)
+    {
+        $event->tag->localised_last_discussion = '{}';
+
+        return $event;
+    }
+}

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+ * This file is part of fof/discussion-language.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\DiscussionLanguage\Listener;
+
+use Flarum\Discussion\Discussion;
+use Flarum\Discussion\Event\Deleted;
+use Flarum\Discussion\Event\Hidden;
+use Flarum\Discussion\Event\Restored;
+use Flarum\Discussion\Event\Started;
+use Flarum\Post\Event\Deleted as PostDeleted;
+use Flarum\Post\Event\Hidden as PostHidden;
+use Flarum\Post\Event\Posted;
+use Flarum\Post\Event\Restored as PostRestored;
+
+use Flarum\Tags\Event\DiscussionWasTagged;
+use Flarum\Tags\Tag;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
+
+class UpdateTagMetadata
+{
+    /**
+     * @param Dispatcher $events
+     */
+    public function subscribe(Dispatcher $events)
+    {
+        $events->listen(Started::class, [$this, 'whenDiscussionIsStarted']);
+        $events->listen(DiscussionWasTagged::class, [$this, 'whenDiscussionWasTagged']);
+        $events->listen(Deleted::class, [$this, 'whenDiscussionIsDeleted']);
+        $events->listen(Hidden::class, [$this, 'whenDiscussionIsHidden']);
+        $events->listen(Restored::class, [$this, 'whenDiscussionIsRestored']);
+
+        $events->listen(Posted::class, [$this, 'whenPostIsPosted']);
+        $events->listen(PostDeleted::class, [$this, 'whenPostIsDeleted']);
+        $events->listen(PostHidden::class, [$this, 'whenPostIsHidden']);
+        $events->listen(PostRestored::class, [$this, 'whenPostIsRestored']);
+    }
+
+    /**
+     * @param Started $event
+     */
+    public function whenDiscussionIsStarted(Started $event)
+    {
+        $this->updateTags($event->discussion, 1);
+    }
+
+    /**
+     * @param DiscussionWasTagged $event
+     */
+    public function whenDiscussionWasTagged(DiscussionWasTagged $event)
+    {
+        $oldTags = Tag::whereIn('id', Arr::pluck($event->oldTags, 'id'))->get();
+
+        $this->updateTags($event->discussion, -1, $oldTags);
+        $this->updateTags($event->discussion, 1);
+    }
+
+    /**
+     * @param Deleted $event
+     */
+    public function whenDiscussionIsDeleted(Deleted $event)
+    {
+        $this->updateTags($event->discussion, -1);
+
+        $event->discussion->tags()->detach();
+    }
+
+    /**
+     * @param Hidden $event
+     */
+    public function whenDiscussionIsHidden(Hidden $event)
+    {
+        $this->updateTags($event->discussion, -1);
+    }
+
+    /**
+     * @param Restored $event
+     */
+    public function whenDiscussionIsRestored(Restored $event)
+    {
+        $this->updateTags($event->discussion, 1);
+    }
+
+    /**
+     * @param Posted $event
+     */
+    public function whenPostIsPosted(Posted $event)
+    {
+        $this->updateTags($event->post->discussion);
+    }
+
+    /**
+     * @param PostDeleted $event
+     */
+    public function whenPostIsDeleted(PostDeleted $event)
+    {
+        $this->updateTags($event->post->discussion);
+    }
+
+    /**
+     * @param PostHidden $event
+     */
+    public function whenPostIsHidden(PostHidden $event)
+    {
+        $this->updateTags($event->post->discussion, 0, null, $event->post);
+    }
+
+    /**
+     * @param PostRestored $event
+     */
+    public function whenPostIsRestored(PostRestored $event)
+    {
+        $this->updateTags($event->post->discussion, 0, null, $event->post);
+    }
+
+    /**
+     * @param \Flarum\Discussion\Discussion $discussion
+     * @param int $delta
+     * @param Tag[]|null $tags
+     * @param Post $post: This is only used when a post has been hidden
+     */
+    protected function updateTags(Discussion $discussion, $delta = 0, $tags = null, $post = null)
+    {
+        if (!$tags) {
+            $tags = $discussion->tags;
+        }
+
+        // If we've just hidden or restored a post, the discussion's last posted at metadata might not have updated yet.
+        // Therefore, we must refresh the last post, even though that might be repeated in the future.
+        if ($post) {
+            $discussion->refreshLastPost();
+        }
+
+        foreach ($tags as $tag) {
+            // We do not count private discussions or hidden discussions in tags
+            if (!$discussion->is_private) {
+                $tag->discussion_count += $delta;
+            }
+
+            $raw_json_string = $tag->localised_last_discussion;
+            if (strlen($raw_json_string) < 2) $raw_json_string = '{}';
+
+            $localisedLastPost = json_decode($raw_json_string, true);
+            $lang = $discussion->language_id;
+
+            // If this is a new / restored discussion, it isn't private, it isn't null,
+            // and it's more recent than what we have now, set it as last posted discussion.
+            if ($delta >= 0 && !$discussion->is_private && $discussion->hidden_at == null &&  (!Arr::exists($localisedLastPost, $lang) || ($discussion->last_posted_at->timestamp >= $localisedLastPost[$lang]['at']))) {
+                $this->setLocalisedLastDiscussion($tag, $discussion);
+            } elseif ($discussion->id == $tag->last_posted_discussion_id) {
+                // This is to persist refreshLastPost above. It is here instead of there so that
+                // if it's not necessary, we save a DB query.
+                if ($post) {
+                    $discussion->save();
+                }
+
+                // This discussion is currently the last posted discussion, but since it didn't qualify for the above check,
+                // it should not be the last posted discussion. Therefore, we should refresh the last posted discussion..
+                if ($lastPostedDiscussion = $tag->discussions()->where('is_private', false)->where('language_id', $lang)->whereNull('hidden_at')->latest('last_posted_at')->first()) {
+                    $this->setLocalisedLastDiscussion($tag, $lastPostedDiscussion);
+                } else {
+                    // No discussions qualify. Remove the last discussion for this language.
+                    $this->removeLocalisedLastDiscussion($tag, $lang);
+                }
+            }
+
+            $tag->save();
+        }
+    }
+
+    private function setLocalisedLastDiscussion(Tag $tag, Discussion $discussion)
+    {
+        $localisedLastPost = json_decode($tag->localised_last_discussion, true);
+        $lang = $discussion->language_id;
+
+        $localisedLastPost[$lang] = [
+            'id' => $discussion->id,
+            'at' => $discussion->last_posted_at->timestamp,
+            'user_id' => $discussion->last_posted_user_id
+        ];
+
+        $tag->localised_last_discussion = json_encode($localisedLastPost);
+    }
+
+    private function removeLocalisedLastDiscussion(Tag $tag, $lang)
+    {
+        $localisedLastPost = json_decode($tag->localised_last_discussion, true);
+
+        if (Arr::exists($localisedLastPost, $lang)) {
+            unset($localisedLastPost[$lang]);
+        }
+
+        $tag->localised_last_discussion = json_encode($localisedLastPost);
+    }
+}


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
- Adds option to only show last posted to discussion that matched the user's locale
- It will use the manually forum locale first, then the auto-detected locale. If these both fail, it'll default to the first available discussion language.
  - Should this actually default to any language?

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
Fix my PHP. Please.

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).