### PR TITLE
Improve query params handling to support search and other extensions

### DIFF
--- a/src/Middleware/AddLanguageFilter.php
+++ b/src/Middleware/AddLanguageFilter.php
@@ -109,7 +109,7 @@ class AddLanguageFilter implements MiddlewareInterface
 
         // If a search is in progress, add the search gambit
         if (Arr::get($params, 'q')) {
-            $newParams['q'] = Arr::get($params, 'q') . ' language:' . $language;
+            $newParams['q'] = Arr::get($params, 'q').' language:'.$language;
         }
 
         return $request->withQueryParams($newParams);

--- a/src/Middleware/AddLanguageFilter.php
+++ b/src/Middleware/AddLanguageFilter.php
@@ -104,9 +104,15 @@ class AddLanguageFilter implements MiddlewareInterface
      */
     private function addQueryParams(ServerRequestInterface $request, array $params, string $language): ServerRequestInterface
     {
-        return $request->withQueryParams(
-            array_merge($params, ['filter' => ['language' => $language]]),
-        );
+        // use recursive merge to preserve filters added by other extensions
+        $newParams = array_merge_recursive($params, ['filter' => ['language' => $language]]);
+
+        // If a search is in progress, add the search gambit
+        if (Arr::get($params, 'q')) {
+            $newParams['q'] = Arr::get($params, 'q') . ' language:' . $language;
+        }
+
+        return $request->withQueryParams($newParams);
     }
 
     private function isDiscussionListPath($request)


### PR DESCRIPTION
This change is required to fully work with Flamarkt Taxonomies, because otherwise Discussion Language overrides the existing filters set on the URL by other extensions depending on the extension loading order.

This also adds support for perma-linking search results.