### PR TITLE
Fix `byobuUserPrivate` page adding language param to API request

### DIFF
--- a/js/src/forum/addLanguageToDiscussionList.js
+++ b/js/src/forum/addLanguageToDiscussionList.js
@@ -37,6 +37,7 @@ export default () => {
     const routeName = app.current.data.routeName;
 
     if (routeName === 'byobuPrivate') return;
+    if (routeName === 'byobuUserPrivate') return;
 
     params.include.push('language');
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
If adding the language filter parameter to the API requests on the `byobuUserPrivate`, no private discussions would ever be shown. This should fix that issue.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
