### PR TITLE
feat: implement CLI command for populating empty fields

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -128,4 +128,7 @@ return [
                     ->beforeSending(CheckNotificationRecipients::class),
             ];
         }),
+
+    (new Extend\Console())
+        ->command(Console\PopulateMissingLanguageFields::class)
 ];

--- a/src/Console/PopulateMissingLanguageFields.php
+++ b/src/Console/PopulateMissingLanguageFields.php
@@ -35,7 +35,9 @@ class PopulateMissingLanguageFields extends AbstractCommand
 
         $updatedRows = 0;
 
-        DB::transaction(function () use (&$updatedRows, $languageMapping) {
+        $connection = DB::connection();
+
+        $connection->transaction(function () use (&$updatedRows, $languageMapping) {
             TagState::whereNull('dl_language_id')
                 ->orderBy('user_id')
                 ->orderBy('tag_id')

--- a/src/Console/PopulateMissingLanguageFields.php
+++ b/src/Console/PopulateMissingLanguageFields.php
@@ -16,7 +16,7 @@ class PopulateMissingLanguageFields extends AbstractCommand
 
     protected function fire()
     {
-        $requiredTables = ['tag_user', 'users', 'discussion_languages', 'test'];
+        $requiredTables = ['tag_user', 'users', 'discussion_languages'];
 
         $schemaBuilder = $this->getSchemaBuilder();
 

--- a/src/Console/PopulateMissingLanguageFields.php
+++ b/src/Console/PopulateMissingLanguageFields.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace FoF\DiscussionLanguage\Console;
+
+use Flarum\Console\AbstractCommand;
+use Illuminate\Database\Capsule\Manager as DB;
+
+class PopulateMissingLanguageFields extends AbstractCommand
+{
+
+    protected function configure()
+    {
+        $this->setName('discussion-language:populate-missing-language-fields')
+            ->setDescription('Populates empty dl_language_id fields in tag_user table with the users preferred language');
+    }
+
+    protected function fire()
+    {
+        $requiredTables = ['tag_user', 'users', 'discussion_languages', 'test'];
+
+        $schemaBuilder = $this->getSchemaBuilder();
+
+        foreach ($requiredTables as $table) {
+            if (!$schemaBuilder->hasTable($table)) {
+                $this->error("Required table for command missing: $table");
+                return;
+            }
+        }
+
+        $this->info('Starting to populate missing language fields...');
+
+        $languageMapping = DB::table('discussion_languages')->pluck('id', 'code')->toArray();
+
+        $updatedRows = 0;
+
+        DB::transaction(function () use (&$updatedRows, $languageMapping) {
+            DB::table('tag_user')->whereNull('dl_language_id')
+                ->orderBy('user_id')
+                ->orderBy('tag_id')
+                ->chunk(100, function ($tagUsers) use (&$updatedRows, $languageMapping) {
+                    foreach ($tagUsers as $tagUser) {
+                        $locale = DB::table('users')
+                            ->where('id', $tagUser->user_id)
+                            ->value('preferences->locale');
+
+                        if ($locale && isset($languageMapping[$locale])) {
+                            DB::table('tag_user')
+                                ->where('user_id', $tagUser->user_id)
+                                ->where('tag_id', $tagUser->tag_id)
+                                ->update(['dl_language_id' => $languageMapping[$locale]]);
+
+                            $updatedRows++;
+                        }
+                    }
+                });
+        });
+
+        $this->info("Total entries updated: $updatedRows.");
+    }
+
+    private function getSchemaBuilder()
+    {
+        return resolve('flarum.db')->getSchemaBuilder();
+    }
+}

--- a/src/Console/PopulateMissingLanguageFields.php
+++ b/src/Console/PopulateMissingLanguageFields.php
@@ -3,9 +3,6 @@
 namespace FoF\DiscussionLanguage\Console;
 
 use Flarum\Console\AbstractCommand;
-use Flarum\Tags\TagState;
-use Flarum\User\User;
-use FoF\DiscussionLanguage\DiscussionLanguage;
 use Illuminate\Database\Capsule\Manager as DB;
 
 class PopulateMissingLanguageFields extends AbstractCommand
@@ -32,20 +29,23 @@ class PopulateMissingLanguageFields extends AbstractCommand
 
         $this->info('Starting to populate missing language fields...');
 
-        $languageMapping = DiscussionLanguage::pluck('id', 'code')->toArray();
+        $languageMapping = DB::table('discussion_languages')->pluck('id', 'code')->toArray();
 
         $updatedRows = 0;
 
         DB::transaction(function () use (&$updatedRows, $languageMapping) {
-            TagState::whereNull('dl_language_id')
+            DB::table('tag_user')->whereNull('dl_language_id')
                 ->orderBy('user_id')
                 ->orderBy('tag_id')
                 ->chunk(100, function ($tagUsers) use (&$updatedRows, $languageMapping) {
                     foreach ($tagUsers as $tagUser) {
-                        $locale = User::where('id', $tagUser->user_id)
+                        $locale = DB::table('users')
+                            ->where('id', $tagUser->user_id)
                             ->value('preferences->locale');
+
                         if ($locale && isset($languageMapping[$locale])) {
-                            TagState::where('user_id', $tagUser->user_id)
+                            DB::table('tag_user')
+                                ->where('user_id', $tagUser->user_id)
                                 ->where('tag_id', $tagUser->tag_id)
                                 ->update(['dl_language_id' => $languageMapping[$locale]]);
 


### PR DESCRIPTION
This PR is related to #53. See the problem description there for why this PR was opened.

**Changes proposed in this pull request:**
- Implement CLI command for retroactively populating empty fields in the `tag_user` table.

**Reviewers should focus on:**
- This command could obviously be improved in many ways, especially regarding performance and error handling. Please ping me if I should have another look at it.
