### PR TITLE
fix: preserve unread-only sticky pinning on /all when language filter is applied

### DIFF
--- a/src/Sticky/PinStickiedDiscussionsToTop.php
+++ b/src/Sticky/PinStickiedDiscussionsToTop.php
@@ -28,21 +28,32 @@ class PinStickiedDiscussionsToTop
             $filters = $filterState->getActiveFilters();
 
             if (count($filters) > 0) {
-                // Use array_filter to check if any of the filters is an instance of TagFilterGambit or LanguageFilterGambit
                 $tagFilterGambits = array_filter($filters, function ($filter) {
-                    return $filter instanceof TagFilterGambit || $filter instanceof LanguageFilterGambit;
+                    return $filter instanceof TagFilterGambit;
                 });
 
-                // Check if there is at least one TagFilterGambit or LanguageFilterGambit instance
+                // Tag pages (with or without a language filter) pin all stickied
+                // discussions to the top, matching core sticky's tag-page behavior.
                 if (count($tagFilterGambits) > 0) {
                     if (!is_array($query->orders)) {
                         $query->orders = [];
                     }
 
                     array_unshift($query->orders, ['column' => 'is_sticky', 'direction' => 'desc']);
+
+                    return;
                 }
 
-                return;
+                // A language-only filter is conceptually still "/all in the user's
+                // language", so fall through to the unread-only UNION path below.
+                // Any other unknown filter: don't interfere.
+                $languageFilterGambits = array_filter($filters, function ($filter) {
+                    return $filter instanceof LanguageFilterGambit;
+                });
+
+                if (count($languageFilterGambits) !== count($filters)) {
+                    return;
+                }
             }
 
             // Otherwise, if we are viewing "all discussions", only pin stickied


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #72: on `/all` with the `AddLanguageFilter` middleware auto-applying `filter[language]=XX`, all stickied discussions were being pinned to the top instead of using core sticky's UNION-based unread-only pinning.

## Background

#68 migrated the language parameter to a proper filter gambit (`filter[language]=XX`). #72 then patched `PinStickiedDiscussionsToTop` to keep sticky pinning working under that gambit, but it routed `LanguageFilterGambit` through the same code path as `TagFilterGambit` — `ORDER BY is_sticky DESC` followed by `return`. With the middleware auto-applying the language filter on every request, `/all` now treats every visit as if it were a tag page: all sticky pin to top, and core sticky's UNION (which floats only *unread* sticky) is bypassed.

## Fix

Distinguish tag-filtered views from language-only-filtered views in the discussion-language replacement of `PinStickiedDiscussionsToTop`:

- **Tag pages** (with or without a language filter) — pin all stickied discussions to the top, matching core sticky's tag-page behavior.
- **Language-only filter** — fall through to the UNION path so only unread sticky pin, matching core sticky's `/all` behavior.
- **Any other unknown filter** — return without interfering (unchanged).

## Behavior matrix

| View | Before this fix | After this fix |
|---|---|---|
| Tag page (with or without language) | All sticky pinned | All sticky pinned (unchanged) |
| `/all` with auto-applied language filter | All sticky pinned (regression) | Unread-only sticky pinned (correct) |
| `/all` without language filter | Unread-only sticky pinned | Unread-only sticky pinned (unchanged) |

## Test plan

- [ ] Enable `fof-discussion-language.filter_language_on_http_request` so the middleware auto-applies a language on every request.
- [ ] Visit `/all` and confirm: a sticky discussion with an old `last_posted_at` no longer floats above newer non-sticky activity, unless it is unread for the current user.
- [ ] Visit a tag page (with or without `?language=XX`) and confirm: all sticky still pin to the top.
- [ ] Confirm `/all` without the middleware behaves the same as before (unread sticky pin to top, read sticky at natural position).

## Related

- Regression introduced in #72.
- Latent gap exposed by the gambit migration in #68.
