### PR TITLE
fix: ignore non-string language query parameter

### DIFF
--- a/src/Middleware/AddLanguageFilter.php
+++ b/src/Middleware/AddLanguageFilter.php
@@ -52,7 +52,10 @@ class AddLanguageFilter implements MiddlewareInterface
         $params = $request->getQueryParams();
 
         // Request has a language parameter, so we handle the request with the language filter applied.
-        if ($language = Arr::get($params, 'language')) {
+        // The `is_string` guard ignores malformed input like `?language[]=foo` or `?language[$ne]=10`
+        // (commonly seen from security scanners) instead of letting an array reach the string-typed
+        // `addQueryParams()` and crash with a TypeError.
+        if (($language = Arr::get($params, 'language')) && is_string($language)) {
             $request = $this->addQueryParams($request, $params, $language);
 
             return $handler->handle($request);

--- a/tests/integration/api/MiddlewareLanguageFilterTest.php
+++ b/tests/integration/api/MiddlewareLanguageFilterTest.php
@@ -195,6 +195,37 @@ class MiddlewareLanguageFilterTest extends TestCase
 
     /**
      * @test
+     *
+     * @dataProvider routesProvider
+     *
+     * Regression: security scanners (e.g. Intigriti / bug-bounty probes) send payloads like
+     * `?language[$ne]=10` which made `Arr::get($params, 'language')` return an array, and that
+     * array was then passed to `addQueryParams(..., string $language)` causing a TypeError /
+     * HTTP 500. The middleware must ignore non-string language values and fall through.
+     */
+    public function non_string_language_parameter_is_ignored_frontend(string $route)
+    {
+        $payloads = [
+            ['language' => ['$ne' => '10']],
+            ['language' => ['de']],
+            ['language' => ''],
+        ];
+
+        foreach ($payloads as $query) {
+            $response = $this->send(
+                $this->request('GET', "/$route")->withQueryParams($query)
+            );
+
+            $this->assertEquals(
+                200,
+                $response->getStatusCode(),
+                'Malformed language query should not cause a server error: '.json_encode($query)
+            );
+        }
+    }
+
+    /**
+     * @test
      */
     public function discussions_are_filtered_by_language_parameter_api()
     {


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
